### PR TITLE
A changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,35 @@
+Change Log
+==========
+
+0.2.3
+-----
+
+* `ConfiguratedApp`: Use deployconfigs overrides dropped in by Chef.
+
+0.2.2
+-----
+
+* `DjangoApp`: Bug fix for virtualhost snippets for services.
+
+0.2.1
+-----
+
+* `DjangoApp`: ``collectstatic`` is no longer run by default. Set the
+  ``has_static`` attribute to run it.
+
+0.2.0
+-----
+
+* `DjangoApp`:
+
+  - The ``vhost_path`` and ``vhost_snippet_path`` are configurable via
+    class attributes.
+  - Virtualhost snippets for services can be named
+    ``deploy/templates/apache2/vhost-snippet.conf.template``.
+  - If the ``compile_i18n`` attribute is set, ``compilemessages`` will
+    be run during preparation.
+
+0.1
+---
+
+* Initial release.


### PR DESCRIPTION
Now that we've got some momentum, things are changing.

I've already bumped `yola.deploy` requirements, without remembering that `collectstatic` isn't run by default any more.

Are we up to maintaining a changelog? I think it'd be useful
