### PR TITLE
It's a cruel world

### DIFF
--- a/yola/deploy/artifacts.py
+++ b/yola/deploy/artifacts.py
@@ -178,13 +178,13 @@ class LocalArtifacts(ArtifactsBase):
             os.makedirs(parentdir)
         shutil.copy(source, artifactpath)
 
+        # Update the version file
+        self._versions.add_version(version, datetime.datetime.now(), meta)
+
         # Update symlink to the latest version
         if os.path.exists(self._local_artifact):
             os.remove(self._local_artifact)
         os.symlink(os.path.basename(artifactpath), self._local_artifact)
-
-        # Update the version file
-        self._versions.add_version(version, datetime.datetime.now(), meta)
 
     def download(self, dest=None, version=None):
         '''Download artificact to dest'''

--- a/yola/deploy/tests/test_artifacts.py
+++ b/yola/deploy/tests/test_artifacts.py
@@ -170,6 +170,22 @@ class TestLocalArtifacts(TmpDirTestCase):
         self.artifacts.upload(self.tmppath('a.tar.gz'))
         self.assertNotEqual(os.readlink(symlink), old_symlink)
 
+    def test_re_upload_ro_state_file(self):
+        '''If we can't write to the state file, we shouldn't corrupt our
+        artifact store'''
+        self._sample_data()
+        symlink = self.tmppath('artifacts', 'test', 'test.tar.gz')
+        old_symlink = os.readlink(symlink)
+
+        os.chmod(self.tmppath('state', 'artifacts', 'test',
+                              'test.tar.gz.versions'), 0400)
+
+        self.create_tar('a.tar.gz', 'foo/bar')
+        self.assertRaises(IOError, self.artifacts.upload,
+                          self.tmppath('a.tar.gz'))
+
+        self.assertEqual(os.readlink(symlink), old_symlink)
+
     def test_list(self):
         self._sample_data()
         self.assertEqual(self.artifacts.list(), ['test.tar.gz'])


### PR DESCRIPTION
This branch contains a bunch of improvements to error handling in non-perfect situations.

Displaying a useful error is possible a little better than having people having to use me as a traceback interpretation service :)

Includes a refactoring of our S3 version history iteration. I'm sure that thought was totally broken, once before, and then convinced myself that no, it was correct. But I can't convince myself of that, this time, so, REFACTOR!
