### PR TITLE
Add docstring for AuthenticatedApp.

### DIFF
--- a/yola/deploy/hooks/htpasswd.py
+++ b/yola/deploy/hooks/htpasswd.py
@@ -31,7 +31,7 @@ class AuthenticatedApp(ConfiguratedApp):
                 'appname': {
                     'htpassword': {
                         'clients': ['myyola', 'sitebuilder', 'yolacom'],
-                        'users': {'yoladmin': 'password'}
+                        'users': {'yoladmin': 'password'},
                     }
                 }
             }


### PR DESCRIPTION
Mostly thanks to @vhata and poking around rankmonitor, I was able to piece together how I should set up authentication for the new localboost service.

This pull request documents it by adding a docstring to AuthenticatedApp. Please make sure the it's accurate. I've yet to actually do this.
