### PR TITLE
We can't conflate targets and branches entirely

### DIFF
--- a/yola/deploy/cmds/build_artifact.py
+++ b/yola/deploy/cmds/build_artifact.py
@@ -372,7 +372,7 @@ def main():
         for rbranch in rbranches.spltlines():
             if ' -> ' in rbranch:
                 continue
-            remote, branch = rbranch.split('/', 1)
+            remote, branch = rbranch.strip().split('/', 1)
             break
 
     version = os.environ.get('BUILD_NUMBER')


### PR DESCRIPTION
https://github.com/yola/yola.deploy/pull/18 was wrong.

On int-envs, we want to build branches to the master target
