### PR TITLE
Deploy to tomcat without restarting it

### DIFF
--- a/yodeploy/hooks/tomcat.py
+++ b/yodeploy/hooks/tomcat.py
@@ -60,5 +60,7 @@ class TomcatServlet(ConfiguratedApp, TemplatedApp):
             if os.path.exists(dest):
                 os.unlink(dest)
         else:
-            dest = os.path.join(contexts, 'ROOT##%s' % self.version)
+            # Versions aren't strictly numeric
+            version = ('%10s' % self.version).replace(' ', '0')
+            dest = os.path.join(contexts, 'ROOT##%s' % version)
         os.symlink(self.deploy_path(self.app), dest)


### PR DESCRIPTION
Fixes #25.

With parallel deploys on tomcat7 \o/

To use this, in `server.xml`, we must change:

``` xml
        <Host 
            name="siteservice.foo.env.yola.net" 
            appBase="/srv/siteservice/live"
            unpackWARs="true" 
            autoDeploy="true">

            <Context 
                displayName="siteservice.foo.env.yola.net" 
                docBase="siteservice"
                path="/" />

            <Valve 
                className="org.apache.catalina.valves.AccessLogValve" 
                directory="logs" 
                prefix="siteservice_access_log." 
                suffix=".log" 
                pattern="common" 
                resolveHosts="false"/>

        </Host>
```

to:

``` xml
        <Host 
            name="siteservice.foo.env.yola.net" 
            appBase="/srv/siteservice/tomcat-contexts"
            unpackWARs="true" 
            autoDeploy="true"
            undeployOldVersions="true">

            <Valve 
                className="org.apache.catalina.valves.AccessLogValve" 
                directory="logs" 
                prefix="siteservice_access_log." 
                suffix=".log" 
                pattern="common" 
                resolveHosts="false"/>

        </Host>
```
