### PR TITLE
default `baseConfig` to stdout and remove unused param

### DIFF
--- a/yodeploy/deploy.py
+++ b/yodeploy/deploy.py
@@ -14,9 +14,9 @@ import yodeploy.repository
 log = logging.getLogger(__name__)
 
 
-def configure_logging(verbose, conf):
+def configure_logging(verbose, conf, filename=None):
     "Set up logging"
-    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+    logging.basicConfig(level=logging.DEBUG, filename=filename, stream=sys.stdout)
     root = logging.getLogger()
 
     for handler in root.handlers:


### PR DESCRIPTION
Two things:
- removing `filename` param since logging is configured using `opts.deploy_settings.logging` - I'm looking [here](https://github.com/yola/yodeploy/blob/master/yodeploy/cmds/deploy.py#L86) and don't see it called anywhere else
- since filename is always `None`, basicConfig sets the default handler to STDERR.

Why do I care?!  Because when putting yodeploy into yolabox, I'd love to see the output of the install.  This is easily done using `Chef::ShellOut` but only STDOUT is piped (and if yodeploy's basicConfig is writing to STDERR, I can't see shit).
