### PR TITLE
Sort os.listdir results, there are no sorting guarantees

### DIFF
--- a/yodeploy/tests/test_application.py
+++ b/yodeploy/tests/test_application.py
@@ -288,5 +288,5 @@ hooks = Hooks
         self.app.gc(2)
         self.assertEqual(self.app.deployed_versions, ['8', '9'])
         self.assertEqual(
-            os.listdir(self.tmppath('srv', 'test', 'virtualenvs')),
+            sorted(os.listdir(self.tmppath('srv', 'test', 'virtualenvs'))),
             ['8', '9'])


### PR DESCRIPTION
#73 was actually right, but had an unecessary sorted.
