### PR TITLE
Add test-only option to build-artifact

### DIFF
--- a/yodeploy/cmds/build_artifact.py
+++ b/yodeploy/cmds/build_artifact.py
@@ -220,7 +220,7 @@ def parse_args(default_app):
     group.add_argument('-T', '--skip-tests', action='store_true',
                        help="Don't run tests")
     group.add_argument('--test-only', action='store_true',
-                       help="Only test (e.g. build virtualenv and  run "
+                       help="Only test (e.g. build virtualenv and run "
                             "test.sh) don't build/upload")
     parser.add_argument('--target', default='master',
                         help='The target to upload to')


### PR DESCRIPTION
Pulled out the test command so it can be run on it's own.

Running test.sh should be independent of build.sh/dist.sh, it isn't
currently for all our projects, but that's a problem we can solve once
we start using this option.
