### PR TITLE
Send through a more correct URL

### DIFF
--- a/yodeploy/cmds/build_artifact.py
+++ b/yodeploy/cmds/build_artifact.py
@@ -58,7 +58,7 @@ class Builder(object):
             'state': status,
             'target_url': target_url,
             'description': description,
-            'context': 'yodeploy/%s' % build_environment
+            'context': 'yodeploy/%s' % build_environment,
         }
         req = urllib2.Request(
             url=url,


### PR DESCRIPTION
And also context, since we might run tests on int-envs and production.
