### PR TITLE
Append a label if it's set

### DIFF
--- a/yodeploy/cmds/build_artifact.py
+++ b/yodeploy/cmds/build_artifact.py
@@ -53,12 +53,19 @@ class Builder(object):
         url = ('https://api.github.com/repos/%(repo)s/statuses/%(commit)s'
                % subst)
         target_url = os.environ.get('BUILD_URL', settings.url % subst)
+
         build_environment = self.deploy_settings.artifacts.environment
+        build_label = os.environ.get('label', None)
+
+        context = 'yodeploy/%s' % build_environment
+        if build_label:
+            context += '/%s' % build_label
+
         data = {
             'state': status,
             'target_url': target_url,
             'description': description,
-            'context': 'yodeploy/%s' % build_environment,
+            'context': context,
         }
         req = urllib2.Request(
             url=url,


### PR DESCRIPTION
The multiconfiguration jobs in jenkins set a label, let's set a unique context per job

https://github.com/blog/1935-see-results-from-all-pull-request-status-checks
