### PR TITLE
Support xunit-integration and missing skip item

### DIFF
--- a/yodeploy/cmds/build_artifact.py
+++ b/yodeploy/cmds/build_artifact.py
@@ -109,20 +109,15 @@ class Builder(object):
             failed = True
 
         msg = 'Tests %s' % ('failed' if failed else 'passed')
-
-        # This stops KeyError on the dict interpolation for javascript tests
-        # since there isn't a 'skip' key in their xunit output
-        results = Counter(skip=0)
+        results = Counter(tests=0, failures=0, errors=0, skip=0)
 
         for report_file in ('xunit', 'xunit-integration'):
             report_path = 'test_build/reports/%s.xml' % report_file
             if os.path.isfile(report_path):
                 report_tree = ElementTree.parse(report_path)
-                results_dict = {}
                 for (k, v) in report_tree.find('testsuite').attrib.iteritems():
-                    if k in ('tests', 'failures', 'errors', 'skip'):
-                        results_dict[k] = int(v)
-                results.update(results_dict)
+                    if k in results:
+                        results[k] += int(v)
                 msg = ('Ran %(tests)s tests: %(failures)s failures, '
                        '%(errors)s errors, %(skip)s skipped') % results
             self.set_commit_status('failure' if failed else 'success', msg)


### PR DESCRIPTION
This now checks for xunit and xunit-integration reports.

It also supports a missing  attribute in the `skip` tag, since
Karma/javascript's xunit reports don't include it.
