### PR TITLE
The root is testsuite or testsuites

### DIFF
--- a/yodeploy/cmds/build_artifact.py
+++ b/yodeploy/cmds/build_artifact.py
@@ -115,8 +115,9 @@ class Builder(object):
         for report_file in ('xunit', 'xunit-integration'):
             report_path = 'test_build/reports/%s.xml' % report_file
             if os.path.isfile(report_path):
-                report_tree = ElementTree.parse(report_path)
-                for (k, v) in report_tree.find('testsuite').attrib.iteritems():
+                test_tree = ElementTree.parse(report_path)
+                test_suite = test_tree.find('testsuite') or test_tree.getroot()
+                for (k, v) in test_suite.attrib.iteritems():
                     if k in results:
                         results[k] += int(v)
                 msg = ('Ran %(tests)s tests: %(failures)s failures, '


### PR DESCRIPTION
So I rather ignorantly expected `ElementTree.find()` to include the root
in the tree of tags it searched, however that is not the case, and for
nosetest xunit XML it returns None, even though the root tag is
`testsuite`.

I was going to use `ElementTree.getroot().tag` and an `if` to check if the root tag
was `testsuite`, however the `or` is cleaner.
