### PR TITLE
Replace webhook with fieldhq key for report_services

### DIFF
--- a/yodeploy/deploy.py
+++ b/yodeploy/deploy.py
@@ -68,11 +68,11 @@ def report(app, action, old_version, version, deploy_settings):
             'fqdn': fqdn,
             'environment': environment,
         }
-        for fieldhq_url in service_settings.urls:
-            log.info('Sending deploy information to FieldHQ (%s)', fieldhq_url)
+        for webhook_url in service_settings.urls:
+            log.info('Sending deploy information to webhook: %s', webhook_url)
             try:
                 requests.post(
-                    fieldhq_url, data=json.dumps(payload),
+                    webhook_url, data=json.dumps(payload),
                     headers={'Content-type': 'application/json'})
             except RequestException as e:
                 log.warning('Could not send post-deploy webhook: %s', e)


### PR DESCRIPTION
A webhooks item is more accurately named.

This will also make the new yodeploy logic easier to release, since
it'll support a `webhooks` or `webhook` service.

The main reason for this new item is so we can use a list of services
to report to QA and Production FieldHQ.

I've dropped the `username` and `password` keys, for the day we give QA
and Production different auth details.

Depends on https://github.com/yola/chef/pull/1225
