### PR TITLE
Use branch for Jenkins description

### DIFF
--- a/yodeploy/cmds/build_artifact.py
+++ b/yodeploy/cmds/build_artifact.py
@@ -144,7 +144,8 @@ class Builder(object):
             jenkins_tag = ' (tag: %s)' % self.tag
         print
         print ('Jenkins description: %s:%.8s%s "%s"'
-               % (self.branch, self.commit, jenkins_tag, self.commit_msg))
+               % (self.branch.replace('origin/', ''), self.commit,
+                  jenkins_tag, self.commit_msg))
 
 
 class BuildCompat1(Builder):


### PR DESCRIPTION
Jenkins shows a short summary of the build in the Build History pane. On
int-envs this is always 'master' because target is always master, no
matter the branch name.

Changing this output to the branch name will be less confusing when
building custom branches on int-envs.

Production behaviour should stay the same because target==branch.

Note that the branch name is normally `origin/branch`. Do we want to strip `^origin/` or are we happy with it?
