### PR TITLE
Add deploy directory to the config.

### DIFF
--- a/yodeploy/hooks/configurator.py
+++ b/yodeploy/hooks/configurator.py
@@ -69,8 +69,12 @@ class ConfiguratedApp(TemplatedApp):
                                      self.settings.artifacts.environment,
                                      self.settings.artifacts.cluster,
                                      configs_dirs, app_conf_dir)
-            config = smush_config(
-                sources, initial={'yoconfigurator': {'app': self.app}})
+
+            initial = {
+                'yoconfigurator': {'app': self.app},
+                'deploy_dir': self.deploy_dir,
+            }
+            config = smush_config(sources, initial=initial)
 
             public_filter_pn = os.path.join(app_conf_dir, 'public-data.py')
             public_config = filter_config(config, public_filter_pn)


### PR DESCRIPTION
This is to configure a django 1.8 app.

Collectstatic now requires `static_root` location.

Example of how this change is used:
https://github.com/yola/bottomline/commit/b4f31761df49de78e171fc27c893f29b1d2c777c
