### PR TITLE
Clean git commit messages to be ascii

### DIFF
--- a/yodeploy/cmds/build_artifact.py
+++ b/yodeploy/cmds/build_artifact.py
@@ -444,8 +444,11 @@ class GitHelper(object):
 
     @property
     def commit_msg(self):
-        return check_output(
-            ('git', 'show', '-s', '--format=%s', self.commit)).strip()
+        git_show = ('git', 'show', '-s', '--format=%s', self.commit)
+        msg = check_output(git_show).strip()
+        # amazon gets unhappy when you attach non-ascii meta
+        ascii_msg = msg.decode('utf-8').encode('ascii', 'replace')
+        return ascii_msg
 
     @property
     def tag(self):

--- a/yodeploy/cmds/tests/test_build_artifact.py
+++ b/yodeploy/cmds/tests/test_build_artifact.py
@@ -1,1 +1,23 @@
-import yodeploy.cmds.build_artifact
+# -*- coding: utf-8 -*-
+from yodeploy.cmds.build_artifact import GitHelper
+from unittest import TestCase
+from mock import patch
+
+
+class TestGitHelper(TestCase):
+
+    def setUp(self):
+        self.patcher = patch('yodeploy.cmds.build_artifact.check_output')
+        self.check_output = self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+        self.git = GitHelper()
+
+    def test_uses_get_show_for_the_commit_message(self):
+        self.check_output.return_value = 'my commit message'
+        self.assertEqual(self.git.commit_msg, 'my commit message')
+        git_call = self.check_output.call_args[0][0][0:2]
+        self.assertEqual(git_call, ('git', 'show'))
+
+    def test_removes_special_chars_from_the_commit_message(self):
+        self.check_output.return_value = 'frosty the ☃'
+        self.assertEqual(self.git.commit_msg, 'frosty the ?')


### PR DESCRIPTION
Since they are used as artifact meta, and in turn amazon headers.

fixes #157 
