### PR TITLE
use django version to determine if `syncdb` or `migrate` should be run

### DIFF
--- a/yodeploy/hooks/django.py
+++ b/yodeploy/hooks/django.py
@@ -1,9 +1,10 @@
 import errno
 import logging
 import os
-import re
 import subprocess
 import sys
+
+from pkg_resources import parse_version
 
 from yodeploy.hooks.apache import ApacheHostedApp, ApacheMultiSiteApp
 from yodeploy.hooks.python import PythonApp
@@ -11,19 +12,6 @@ from yodeploy.util import chown_r, ignoring, touch
 
 
 log = logging.getLogger(__name__)
-
-
-def parse_django_version(version):
-    """Convert a version string to a version tuple.
-
-    Examples:
-    '1.7' -> (1, 7)
-    '1.10a1' -> (1, 10)
-    '2.0' -> (2, 0)
-    """
-    version = version.strip()
-    matches = re.match(r'^(\d+)\.(\d+).*', version)
-    return tuple(map(int, matches.groups()))
 
 
 class DjangoApp(ApacheHostedApp, PythonApp):
@@ -107,7 +95,7 @@ class DjangoApp(ApacheHostedApp, PythonApp):
 
     @property
     def django_version(self):
-        return parse_django_version(self.manage_py('version'))
+        return tuple(parse_version(self.manage_py('version')))
 
     def run_migrate_commands(self):
         if self.django_version >= (1, 7,):

--- a/yodeploy/hooks/tests/test_django.py
+++ b/yodeploy/hooks/tests/test_django.py
@@ -2,7 +2,7 @@ import unittest
 
 from mock import PropertyMock, call, patch
 
-from yodeploy.hooks.django import DjangoApp, parse_django_version
+from yodeploy.hooks.django import DjangoApp
 
 
 class TestDjangoHook(unittest.TestCase):
@@ -12,17 +12,6 @@ class TestDjangoHook(unittest.TestCase):
 
     def test_vhost_attributes(self):
         self.assertEqual(self.dh.vhost_path, '/etc/apache2/sites-enabled')
-
-
-class TestParseDjangoVersion(unittest.TestCase):
-    def test_parses_major_and_minor_from_alpha_version_number(self):
-        self.assertEqual(parse_django_version('1.9a1'), (1, 9))
-
-    def test_parses_double_digit_minor_version(self):
-        self.assertEqual(parse_django_version('1.10'), (1, 10))
-
-    def test_parses_single_digit_minor_version(self):
-        self.assertEqual(parse_django_version('1.5'), (1, 5))
 
 
 class TestDjangoMigrateCommand(unittest.TestCase):

--- a/yodeploy/hooks/tests/test_django.py
+++ b/yodeploy/hooks/tests/test_django.py
@@ -1,5 +1,8 @@
 import unittest
-from yodeploy.hooks.django import DjangoApp
+
+from mock import PropertyMock, call, patch
+
+from yodeploy.hooks.django import DjangoApp, parse_django_version
 
 
 class TestDjangoHook(unittest.TestCase):
@@ -9,3 +12,54 @@ class TestDjangoHook(unittest.TestCase):
 
     def test_vhost_attributes(self):
         self.assertEqual(self.dh.vhost_path, '/etc/apache2/sites-enabled')
+
+
+class TestParseDjangoVersion(unittest.TestCase):
+    def test_parses_major_and_minor_from_alpha_version_number(self):
+        self.assertEqual(parse_django_version('1.9a1'), (1, 9))
+
+    def test_parses_double_digit_minor_version(self):
+        self.assertEqual(parse_django_version('1.10'), (1, 10))
+
+    def test_parses_single_digit_minor_version(self):
+        self.assertEqual(parse_django_version('1.5'), (1, 5))
+
+
+class TestDjangoMigrateCommand(unittest.TestCase):
+    def setUp(self):
+        django_version_patcher = patch.object(
+            DjangoApp, 'django_version', new_callable=PropertyMock)
+        self.mock_django_version = django_version_patcher.start()
+        self.addCleanup(django_version_patcher.stop)
+
+        manage_py_patcher = patch.object(DjangoApp, 'manage_py')
+        self.mock_manage_py = manage_py_patcher.start()
+        self.addCleanup(manage_py_patcher.stop)
+
+        self.dh = DjangoApp('test', None, '/tmp/test', '123', {}, None)
+
+    def test_call_syncdb_for_django_1_5(self):
+        """Call syncdb for django 1.5"""
+        self.mock_django_version.return_value = (1, 5)
+        self.dh.run_migrate_commands()
+        self.mock_manage_py.assert_called_once_with('syncdb', '--noinput')
+
+    def test_call_syncdb_then_migrate_for_django_1_5_with_migrations(self):
+        """Call syncdb then migrate for Django 1.5 with migrations"""
+        self.mock_django_version.return_value = (1, 5)
+        self.dh.has_migrations = True
+        self.dh.run_migrate_commands()
+        self.mock_manage_py.assert_has_calls(
+            [call('syncdb', '--noinput'), call('migrate')])
+
+    def test_call_migrate_for_django_1_7(self):
+        """Call migrate for Django 1.7"""
+        self.mock_django_version.return_value = (1, 7)
+        self.dh.run_migrate_commands()
+        self.mock_manage_py.assert_called_once_with('migrate', '--noinput')
+
+    def test_call_migrate_for_django_1_10(self):
+        """Call migrate for Django 1.10"""
+        self.mock_django_version.return_value = (1, 10)
+        self.dh.run_migrate_commands()
+        self.mock_manage_py.assert_called_once_with('migrate', '--noinput')


### PR DESCRIPTION
Fixes https://github.com/yola/yodeploy/issues/172

`DjangoApp.migrate` was still running `syncdb`.

`syncdb` was an alias for `migrate` in django 1.7 and 1.8
`syncdb` was removed in django 1.9

This checks the django version to see if `syncdb` or `migrate` should be run so it will work on Django 1.9+ without having to override `migrate`.