### PR TITLE
Fix a couple of locking races

### DIFF
--- a/yodeploy/locking.py
+++ b/yodeploy/locking.py
@@ -60,7 +60,6 @@ class LockFile(object):
     def release(self):
         if not self.held:
             raise UnlockedException("We don't hold a lock")
-        fcntl.flock(self._f, fcntl.LOCK_UN)
         os.unlink(self.filename)
         os.close(self._f)
         self._f = None

--- a/yodeploy/locking.py
+++ b/yodeploy/locking.py
@@ -18,7 +18,7 @@ class LockFile(object):
     """A simple on-disk Unix lock file.
     Automatically cleans up stale lock files.
 
-    Locking on unix is harder that one would like. Asthetically, we don't want
+    Locking on unix is harder that one would like. Aesthetically, we don't want
     to leave closed lock files lying around. But this means we have to jump
     through some hoops to ensure that all users are actually using the same
     file, and nobody is holding an fcntl lock on a deleted lock file.

--- a/yodeploy/locking.py
+++ b/yodeploy/locking.py
@@ -18,6 +18,15 @@ class UnlockedException(Exception):
 class LockFile(object):
     """A simple on-disk Unix lock file.
     Automatically cleans up stale lock files.
+
+    Locking on unix is harder that one would like. Asthetically, we don't want
+    to leave closed lock files lying around. But this means we have to jump
+    through some hoops to ensure that all users are actually using the same
+    file, and nobody is holding an fcntl lock on a deleted lock file.
+
+    O_CREAT | O_EXCL has no ability to differentiate between locked and stale
+    lockfiles, so we use POSIX fcntl locks. And ensure that the lock file we
+    hold is the one that the next consumer will check.
     """
     def __init__(self, filename):
         self.filename = filename

--- a/yodeploy/tests/test_locking.py
+++ b/yodeploy/tests/test_locking.py
@@ -1,4 +1,7 @@
+import mock
+import os
 import threading
+import time
 
 from yodeploy.tests import TmpDirTestCase
 from yodeploy.locking import (LockFile, LockedException, SpinLockFile,
@@ -58,6 +61,38 @@ class LockFileTest(TmpDirTestCase):
         lf = LockFile(self.tmppath('lockfile'))
         with lf:
             self.assertRaises(LockedException, lf.acquire)
+
+    def test_held_is_false_when_aquire_failed(self):
+        lf1 = LockFile(self.tmppath('lockfile'))
+        lf1.acquire()
+
+        lf2 = LockFile(self.tmppath('lockfile'))
+        lf2.try_acquire()
+        self.assertFalse(lf2.held)
+
+    def test_avoids_holding_deleted_lock(self):
+        lf1 = LockFile(self.tmppath('lockfile'))
+        lf1.acquire()
+        lf2 = LockFile(self.tmppath('lockfile'))
+
+        original = os.open
+
+        def slow_open(*args, **kwargs):
+            r = original(*args, **kwargs)
+            time.sleep(0.2)
+            return r
+
+        def acquire():
+            with mock.patch('os.open', new=slow_open):
+                lf2.try_acquire()
+
+        t = threading.Thread(target=acquire)
+        t.start()
+        time.sleep(0.1)
+        lf1.release()
+
+        t.join()
+        self.assertFalse(lf2.held)
 
 
 class SpinLockFileTest(TmpDirTestCase):


### PR DESCRIPTION
The first didn't actually race in `acquire()`, but appeared as a race to the consumer, because the `held` property was true, even though the lock wasn't held, after a failed `acquire()` attempt.

The second, subtler race was that the `fcntl` lock could be held on a file that another process was in the process of releasing and deleting. We fix this by checking that the our file is still in the filesystem, after taking the lock.

Fixes: #176