### PR TITLE
Use pip rather than easy_install

### DIFF
--- a/scripts/local-deploy-bootstrap.py
+++ b/scripts/local-deploy-bootstrap.py
@@ -278,18 +278,12 @@ def bootstrap_virtualenv(virtualenv_path=None):
 
     check_call(cmd)
 
-    packages = []
-    with open('requirements.txt') as f:
-        for line in f:
-            line = line.strip()
-            if line.startswith('#') or not line:
-                continue
-            packages.append(line)
-
-    check_call(['bootstrap_ve/bin/python',
-                'bootstrap_ve/bin/easy_install',
-                '-i', deploy_settings().build.pypi,
-               ] + packages)
+    check_call([
+        'bootstrap_ve/bin/python',
+        '-m', 'pip', 'install',
+        '--index-url', deploy_settings().build.pypi,
+        '-r', 'requirements.txt'
+    ])
 
 
 def find_required_version(package):
@@ -380,7 +374,7 @@ def build_virtualenv(bootstrap=False):
              '-m', 'yodeploy.cmds.build_virtualenv')) == 0:
         return
 
-    # Bootstrap a virtualenv with easy_install
+    # Bootstrap a virtualenv
     if binary_available('virtualenv'):
         bootstrap_virtualenv()
     else:

--- a/yodeploy/application.py
+++ b/yodeploy/application.py
@@ -16,11 +16,11 @@ log = logging.getLogger(__name__)
 
 
 class Application(object):
-    '''A deployable application.
+    """A deployable application.
 
     The deploy can be driven piece by piece, or by the deploy() function which
     will do it all in the right order.
-    '''
+    """
 
     def __init__(self, app, settings_file):
         self.app = app
@@ -49,9 +49,11 @@ class Application(object):
                       key=version_sort_key)
 
     def deploy_ve(self, target, repository, app_version):
-        '''Unpack a virtualenv for the deploy hooks, and return its location
-        on the FS
-        '''
+        """Prepare the deploy virtualenv.
+
+        Unpack a virtualenv for the deploy hooks, and return its location on
+        the FS.
+        """
         deploy_req_fn = os.path.join(self.appdir, 'versions', app_version,
                                      'deploy', 'requirements.txt')
         hash_ = yodeploy.virtualenv.sha224sum(deploy_req_fn)
@@ -129,7 +131,7 @@ class Application(object):
         log.info('Deployed %s/%s', self.app, version)
 
     def unpack(self, target, repository, version):
-        '''First stage of deployment'''
+        """First stage of deployment"""
         assert self.lock.held
         log.debug('Unpacking %s/%s', self.app, version)
 
@@ -158,13 +160,13 @@ class Application(object):
                   staging)
 
     def prepare(self, target, repository, version):
-        '''Post-unpack, pre-swing hook'''
+        """Post-unpack, pre-swing hook"""
         assert self.lock.held
         log.debug('Preparing %s/%s', self.app, version)
         self.hook('prepare', target, repository, version)
 
     def swing_symlink(self, version):
-        '''Make version live'''
+        """Make version live"""
         assert self.lock.held
         log.debug('Swinging %s/%s', self.app, version)
         # rename is atomic, symlink isn't
@@ -176,16 +178,17 @@ class Application(object):
         os.rename(temp_link, link)
 
     def deployed(self, target, repository, version):
-        '''Post-swing hook'''
+        """Post-swing hook"""
         assert self.lock.held
         log.debug('Deployed hook %s/%s', self.app, version)
         self.hook('deployed', target, repository, version)
 
     def gc(self, max_versions):
-        '''
+        """Garbage-collect artifacts.
+
         Remove all deployed versions except the most recent max_versions, and
         any live verisons.
-        '''
+        """
         with self.lock:
             old_versions = set(self.deployed_versions[:-max_versions])
             if self.live_version:

--- a/yodeploy/cmds/build_virtualenv.py
+++ b/yodeploy/cmds/build_virtualenv.py
@@ -72,8 +72,9 @@ def main():
     deploy_settings = yodeploy.config.load_settings(options.config)
     repository = yodeploy.repository.get_repository(deploy_settings)
 
-    version = yodeploy.virtualenv.ve_version(
-        yodeploy.virtualenv.sha224sum(options.requirement))
+    ve_hash = yodeploy.virtualenv.sha224sum(options.requirement)
+    platform = deploy_settings.artifacts.platform
+    version = yodeploy.virtualenv.ve_version(ve_hash, platform)
     if options.hash:
         print(version)
         return
@@ -104,7 +105,7 @@ def main():
 
     if not os.path.isdir('virtualenv'):
         yodeploy.virtualenv.create_ve(
-            '.',
+            '.', platform,
             pypi=deploy_settings.build.pypi,
             req_file=options.requirement)
 

--- a/yodeploy/cmds/build_virtualenv.py
+++ b/yodeploy/cmds/build_virtualenv.py
@@ -8,10 +8,10 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
+from yodeploy import virtualenv
 import yodeploy.config
 import yodeploy.repository
 import yodeploy.util
-import yodeploy.virtualenv
 
 log = logging.getLogger(os.path.basename(__file__).rsplit('.', 1)[0])
 
@@ -33,11 +33,11 @@ def main():
                         help='Target to store/retrieve virtualenvs from')
     parser.add_argument('--hash',
                         action='store_true',
-                        help="Only determine the virtualenv's version")
+                        help="Only determine the virtualenv's id")
     parser.add_argument('-u', '--upload',
                         action='store_true',
                         help="Upload the resultant virtualenv to the "
-                             "repository, if there isn't one of this version "
+                             "repository, if there isn't one of this id "
                              "there already")
     parser.add_argument('-d', '--download',
                         action='store_true',
@@ -72,11 +72,10 @@ def main():
     deploy_settings = yodeploy.config.load_settings(options.config)
     repository = yodeploy.repository.get_repository(deploy_settings)
 
-    ve_hash = yodeploy.virtualenv.sha224sum(options.requirement)
     platform = deploy_settings.artifacts.platform
-    version = yodeploy.virtualenv.ve_version(ve_hash, platform)
+    ve_id = virtualenv.get_id(options.requirement, platform)
     if options.hash:
-        print(version)
+        print(ve_id)
         return
 
     existing_ve = os.path.exists('virtualenv')
@@ -85,7 +84,7 @@ def main():
             existing_ve = f.read().strip()
 
     if existing_ve:
-        if existing_ve == version and not options.force:
+        if existing_ve == ve_id and not options.force:
             log.info('Existing virtualenv matches requirements.txt')
             options.download = False
         else:
@@ -94,8 +93,8 @@ def main():
     if options.download:
         downloaded = False
         try:
-            yodeploy.virtualenv.download_ve(repository, options.app,
-                                            version, options.target)
+            virtualenv.download_ve(
+                repository, options.app, ve_id, options.target)
             downloaded = True
         except KeyError:
             log.warn('No existing virtualenv, building...')
@@ -104,14 +103,14 @@ def main():
             yodeploy.util.extract_tar('virtualenv.tar.gz', 'virtualenv')
 
     if not os.path.isdir('virtualenv'):
-        yodeploy.virtualenv.create_ve(
+        virtualenv.create_ve(
             '.', platform,
             pypi=deploy_settings.build.pypi,
             req_file=options.requirement)
 
     if options.upload:
-        yodeploy.virtualenv.upload_ve(
-            repository, options.app, version,
+        virtualenv.upload_ve(
+            repository, options.app, ve_id,
             options.target, overwrite=options.force)
 
 

--- a/yodeploy/hooks/python.py
+++ b/yodeploy/hooks/python.py
@@ -1,9 +1,9 @@
 import logging
 import os
 
+from yodeploy import virtualenv
 from yodeploy.hooks.base import DeployHook
 from yodeploy.util import extract_tar
-from yodeploy.virtualenv import ve_version, sha224sum, download_ve
 
 log = logging.getLogger(__name__)
 
@@ -21,24 +21,24 @@ class PythonApp(DeployHook):
 
     def deploy_ve(self):
         log = logging.getLogger(__name__)
-        hash_ = sha224sum(self.deploy_path('requirements.txt'))
-        version = ve_version(hash_, self.settings.artifacts.platform)
+        ve_id = virtualenv.get_id(self.deploy_path('requirements.txt'),
+                                  self.settings.artifacts.platform)
         ve_working = os.path.join(self.root, 'virtualenvs', 'unpack')
-        ve_dir = os.path.join(self.root, 'virtualenvs', version)
+        ve_dir = os.path.join(self.root, 'virtualenvs', ve_id)
         tarball = os.path.join(ve_working, 'virtualenv.tar.gz')
         ve_unpack_root = os.path.join(ve_working, 'virtualenv')
 
         if not os.path.exists(ve_dir):
-            log.debug('Deploying virtualenv %s', version)
+            log.debug('Deploying virtualenv %s', ve_id)
 
             if not os.path.exists(ve_working):
                 os.makedirs(ve_working)
-            download_ve(self.repository, self.app, version, self.target,
-                        dest=tarball)
+            virtualenv.download_ve(
+                self.repository, self.app, ve_id, self.target, dest=tarball)
             extract_tar(tarball, ve_unpack_root)
             os.rename(ve_unpack_root, ve_dir)
 
         ve_symlink = self.deploy_path('virtualenv')
         if not os.path.exists(ve_symlink):
-            os.symlink(os.path.join('..', '..', 'virtualenvs', version),
+            os.symlink(os.path.join('..', '..', 'virtualenvs', ve_id),
                        ve_symlink)

--- a/yodeploy/hooks/python.py
+++ b/yodeploy/hooks/python.py
@@ -21,23 +21,24 @@ class PythonApp(DeployHook):
 
     def deploy_ve(self):
         log = logging.getLogger(__name__)
-        ve_hash = ve_version(sha224sum(self.deploy_path('requirements.txt')))
+        hash_ = sha224sum(self.deploy_path('requirements.txt'))
+        version = ve_version(hash_, self.settings.artifacts.platform)
         ve_working = os.path.join(self.root, 'virtualenvs', 'unpack')
-        ve_dir = os.path.join(self.root, 'virtualenvs', ve_hash)
+        ve_dir = os.path.join(self.root, 'virtualenvs', version)
         tarball = os.path.join(ve_working, 'virtualenv.tar.gz')
         ve_unpack_root = os.path.join(ve_working, 'virtualenv')
 
         if not os.path.exists(ve_dir):
-            log.debug('Deploying virtualenv %s', ve_hash)
+            log.debug('Deploying virtualenv %s', version)
 
             if not os.path.exists(ve_working):
                 os.makedirs(ve_working)
-            download_ve(self.repository, self.app, ve_hash, self.target,
+            download_ve(self.repository, self.app, version, self.target,
                         dest=tarball)
             extract_tar(tarball, ve_unpack_root)
             os.rename(ve_unpack_root, ve_dir)
 
         ve_symlink = self.deploy_path('virtualenv')
         if not os.path.exists(ve_symlink):
-            os.symlink(os.path.join('..', '..', 'virtualenvs', ve_hash),
+            os.symlink(os.path.join('..', '..', 'virtualenvs', version),
                        ve_symlink)

--- a/yodeploy/test_integration/deployconf.py
+++ b/yodeploy/test_integration/deployconf.py
@@ -1,4 +1,5 @@
 import os
+import sysconfig
 
 
 class AttrDict(dict):
@@ -15,6 +16,7 @@ deploy_settings = AttrDict(
     artifacts=AttrDict(
         cluster='',
         store="local",
+        platform=sysconfig.get_platform(),
         store_settings=AttrDict(
             local=AttrDict(
                 directory=os.path.join(test_dir, 'filesys', 'artifacts')

--- a/yodeploy/test_integration/helpers.py
+++ b/yodeploy/test_integration/helpers.py
@@ -81,7 +81,7 @@ def build_sample(app_name, version='1'):
             '--config', deployconf_fn),
         cwd=app_dir,
         stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE, env=env, universal_newlines=True)
+        stderr=subprocess.PIPE, env=env)
     out, err = p.communicate()
 
     if p.wait() != 0:

--- a/yodeploy/test_integration/test_buildvirtualenv.py
+++ b/yodeploy/test_integration/test_buildvirtualenv.py
@@ -28,11 +28,5 @@ class TestAppWithRequirementsThatDowngrade(unittest.TestCase):
         cleanup_venv('requirements-downgrade')
 
     def test_fails_to_build(self):
-        failed = False
-        try:
+        with self.assertRaises(Exception):
             build_sample('requirements-downgrade')
-        except Exception as e:
-            if 'Requirements were incompatible' not in str(e):
-                raise e
-            failed = True
-        self.assertTrue(failed)

--- a/yodeploy/tests/test_application.py
+++ b/yodeploy/tests/test_application.py
@@ -32,7 +32,8 @@ class ApplicationTestCase(TmpDirTestCase):
 
         if not os.path.exists(self.test_ve_tar_path):
             self._create_test_ve()
-        self._deploy_ve_hash = ve_version(sha224sum(self.test_req_path))
+        ve_hash = sha224sum(self.test_req_path)
+        self._deploy_ve_version = ve_version(ve_hash, 'test')
 
     def _data_path(self, fragment):
         version_suffix = 'py%s' % platform.python_version()
@@ -70,7 +71,7 @@ class ApplicationTestCase(TmpDirTestCase):
         with open(self.test_req_path, 'w') as f:
             f.write('%s\n' % yodeploy_installable)
 
-        create_ve(self.test_ve_path, pypi, verify_req_install=False)
+        create_ve(self.test_ve_path, 'test', pypi, verify_req_install=False)
 
 
 class ApplicationTest(ApplicationTestCase):
@@ -184,14 +185,14 @@ class ApplicationTest(ApplicationTestCase):
         self.assertEqual(self.app.live_version, 'bar')
 
     def test_prepare_hook(self):
-        upload_ve(self.repo, 'deploy', self._deploy_ve_hash,
+        upload_ve(self.repo, 'deploy', self._deploy_ve_version,
                   source=self.test_ve_tar_path)
         with self.app.lock:
             self.app.prepare('master', self.repo, 'foo')
         self.assertTMPPExists('srv', 'test', 'prepare_hook_output')
 
     def test_deployed(self):
-        upload_ve(self.repo, 'deploy', self._deploy_ve_hash,
+        upload_ve(self.repo, 'deploy', self._deploy_ve_version,
                   source=self.test_ve_tar_path)
         with self.app.lock:
             self.app.deployed('master', self.repo, 'foo')
@@ -205,7 +206,7 @@ class ApplicationTest(ApplicationTestCase):
         version = '1'
         with open(self.tmppath('test.tar.gz'), 'rb') as f:
             self.repo.put('test', version, f, {'deploy_compat': '3'})
-        upload_ve(self.repo, 'deploy', self._deploy_ve_hash,
+        upload_ve(self.repo, 'deploy', self._deploy_ve_version,
                   source=self.test_ve_tar_path)
         os.unlink(self.tmppath('test.tar.gz'))
 

--- a/yodeploy/tests/test_application.py
+++ b/yodeploy/tests/test_application.py
@@ -4,11 +4,11 @@ import shutil
 import tarfile
 import time
 
+from yodeploy import virtualenv
 from yodeploy.application import Application
 from yodeploy.locking import LockedException
 from yodeploy.repository import LocalRepositoryStore, Repository
 from yodeploy.tests import TmpDirTestCase
-from yodeploy.virtualenv import create_ve, sha224sum, upload_ve, ve_version
 
 SRC_ROOT = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -32,8 +32,7 @@ class ApplicationTestCase(TmpDirTestCase):
 
         if not os.path.exists(self.test_ve_tar_path):
             self._create_test_ve()
-        ve_hash = sha224sum(self.test_req_path)
-        self._deploy_ve_version = ve_version(ve_hash, 'test')
+        self._deploy_ve_id = virtualenv.get_id(self.test_req_path, 'test')
 
     def _data_path(self, fragment):
         version_suffix = 'py%s' % platform.python_version()
@@ -71,7 +70,8 @@ class ApplicationTestCase(TmpDirTestCase):
         with open(self.test_req_path, 'w') as f:
             f.write('%s\n' % yodeploy_installable)
 
-        create_ve(self.test_ve_path, 'test', pypi, verify_req_install=False)
+        virtualenv.create_ve(
+            self.test_ve_path, 'test', pypi, verify_req_install=False)
 
 
 class ApplicationTest(ApplicationTestCase):
@@ -185,15 +185,15 @@ class ApplicationTest(ApplicationTestCase):
         self.assertEqual(self.app.live_version, 'bar')
 
     def test_prepare_hook(self):
-        upload_ve(self.repo, 'deploy', self._deploy_ve_version,
-                  source=self.test_ve_tar_path)
+        virtualenv.upload_ve(self.repo, 'deploy', self._deploy_ve_id,
+                             source=self.test_ve_tar_path)
         with self.app.lock:
             self.app.prepare('master', self.repo, 'foo')
         self.assertTMPPExists('srv', 'test', 'prepare_hook_output')
 
     def test_deployed(self):
-        upload_ve(self.repo, 'deploy', self._deploy_ve_version,
-                  source=self.test_ve_tar_path)
+        virtualenv.upload_ve(self.repo, 'deploy', self._deploy_ve_id,
+                             source=self.test_ve_tar_path)
         with self.app.lock:
             self.app.deployed('master', self.repo, 'foo')
         self.assertTMPPExists('srv', 'test', 'deployed_hook_output')
@@ -206,8 +206,8 @@ class ApplicationTest(ApplicationTestCase):
         version = '1'
         with open(self.tmppath('test.tar.gz'), 'rb') as f:
             self.repo.put('test', version, f, {'deploy_compat': '3'})
-        upload_ve(self.repo, 'deploy', self._deploy_ve_version,
-                  source=self.test_ve_tar_path)
+        virtualenv.upload_ve(self.repo, 'deploy', self._deploy_ve_id,
+                             source=self.test_ve_tar_path)
         os.unlink(self.tmppath('test.tar.gz'))
 
         self.app.deploy('master', self.repo, version)

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -21,10 +21,8 @@ def sha224sum(filename):
     return m.hexdigest()
 
 
-def ve_version(req_hash):
-    return '%s-%s-%s' % (sysconfig.get_python_version(),
-                         sysconfig.get_platform(),
-                         req_hash)
+def ve_version(req_hash, platform):
+    return '%s-%s-%s' % (sysconfig.get_python_version(), platform, req_hash)
 
 
 def download_ve(repository, app, ve_version, target='master',
@@ -51,7 +49,7 @@ def upload_ve(repository, app, ve_version, target='master',
 
 
 def create_ve(
-        app_dir, pypi=None, req_file='requirements.txt',
+        app_dir, platform, pypi=None, req_file='requirements.txt',
         verify_req_install=True):
     log.info('Building virtualenv')
     ve_dir = os.path.join(app_dir, 'virtualenv')
@@ -65,8 +63,10 @@ def create_ve(
         check_requirements(ve_dir)
 
     relocateable_ve(ve_dir)
+    hash_ = sha224sum(os.path.join(app_dir, req_file))
+    version = ve_version(hash_, platform)
     with open(os.path.join(ve_dir, '.hash'), 'w') as f:
-        f.write(ve_version(sha224sum(os.path.join(app_dir, req_file))))
+        f.write(version)
 
     log.info('Building virtualenv tarball')
     cwd = os.getcwd()

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -67,6 +67,7 @@ def create_ve(
     version = ve_version(hash_, platform)
     with open(os.path.join(ve_dir, '.hash'), 'w') as f:
         f.write(version)
+        f.write('\n')
 
     log.info('Building virtualenv tarball')
     cwd = os.getcwd()

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -104,7 +104,7 @@ def install_requirements(ve_dir, pypi, req_file):
 
 
 def check_requirements(ve_dir):
-    """run pip check"""
+    """Run pip check"""
     p = subprocess.Popen(
         (os.path.join(ve_dir, 'bin', 'python'), '-m', 'pip', 'check'),
         stdout=subprocess.PIPE)


### PR DESCRIPTION
This is long-overdue. We didn't do it because pre-built eggs made virtualenv assembly nice and quick. pip's local wheel building & caching gives many of the same benefits, so we may not need to implement centralised wheel-building.