### PR TITLE
Support Python 3 apps (compat 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Change Log
 ==========
 
+dev
+---
+
+* Add compat 5 for pure Python 3 apps.
+* Internal API changes to `yodeploy.virtualenv`:
+  - Added `get_python_version`, to return the Python version that an app
+    will run under.
+  - `get_id`, `create_ve`, `relocateable_ve` now require a
+    `python_version` argument.
+  - Replaced `install_requirements` with `pip_install`.
+
 0.8.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ source.
 2. The legacy repository with yola.deploy < 0.3. **No longer supported**.
 3. yola.deploy 0.3.x. **No longer supported**.
 4. yodeploy >= 0.4 (after the rename).
+5. Python 3 apps with yodeploy >= 0.8.1.
 
 Testing
 -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ requests==2.13.0
 spec==1.3.1
 virtualenv==15.1.0
 werkzeug==0.11.10
-yoconfigurator==0.5.1
+yoconfigurator==0.5.2

--- a/yodeploy/application.py
+++ b/yodeploy/application.py
@@ -66,8 +66,9 @@ class Application(object):
         """
         deploy_req_fn = os.path.join(self.appdir, 'versions', app_version,
                                      'deploy', 'requirements.txt')
+        python_version = virtualenv.get_python_version(self.compat)
         platform = self.settings.artifacts.platform
-        ve_id = virtualenv.get_id(deploy_req_fn, platform)
+        ve_id = virtualenv.get_id(deploy_req_fn, python_version, platform)
         ves_dir = os.path.join(self.settings.paths.apps, 'deploy',
                                'virtualenvs')
         ve_dir = os.path.join(ves_dir, ve_id)

--- a/yodeploy/application.py
+++ b/yodeploy/application.py
@@ -148,7 +148,7 @@ class Application(object):
 
         with repository.get(self.app, version, target) as f1:
             self.compat = int(f1.metadata.get('deploy_compat', 1))
-            if self.compat not in (4,):
+            if self.compat not in (4, 5):
                 raise Exception('Unsupported artifact: compat level %s'
                                 % self.compat)
             with open(tarball, 'wb') as f2:

--- a/yodeploy/cmds/build_artifact.py
+++ b/yodeploy/cmds/build_artifact.py
@@ -114,7 +114,8 @@ class Builder(object):
                                                     'build_virtualenv'))
         build_deploy_virtualenv = [python, build_ve, '-a', 'deploy',
                                    '--target', self.target, '--download',
-                                   '--config', self.deploy_settings_file]
+                                   '--config', self.deploy_settings_file,
+                                   '--compat=%i' % self.compat]
         build_app_virtualenv = [python, build_ve, '-a', self.app,
                                 '--target', self.target, '--download',
                                 '--config', self.deploy_settings_file]
@@ -223,6 +224,8 @@ class BuildCompat4(Builder):
     compat = 4
 
 
+class BuildCompat5(Builder):
+    compat = 5
 
 
 def parse_args(default_app):
@@ -442,6 +445,7 @@ def main():
     try:
         BuilderClass = {
             4: BuildCompat4,
+            5: BuildCompat5,
         }[compat]
     except KeyError:
         print('Only legacy and yodeploy compat >=4 apps are supported',

--- a/yodeploy/hooks/python.py
+++ b/yodeploy/hooks/python.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sysconfig
 
 from yodeploy import virtualenv
 from yodeploy.hooks.base import DeployHook
@@ -22,6 +23,7 @@ class PythonApp(DeployHook):
     def deploy_ve(self):
         log = logging.getLogger(__name__)
         ve_id = virtualenv.get_id(self.deploy_path('requirements.txt'),
+                                  sysconfig.get_python_version(),
                                   self.settings.artifacts.platform)
         ve_working = os.path.join(self.root, 'virtualenvs', 'unpack')
         ve_dir = os.path.join(self.root, 'virtualenvs', ve_id)

--- a/yodeploy/tests/test_application.py
+++ b/yodeploy/tests/test_application.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import shutil
+import sysconfig
 import tarfile
 import time
 
@@ -32,7 +33,8 @@ class ApplicationTestCase(TmpDirTestCase):
 
         if not os.path.exists(self.test_ve_tar_path):
             self._create_test_ve()
-        self._deploy_ve_id = virtualenv.get_id(self.test_req_path, 'test')
+        self._deploy_ve_id = virtualenv.get_id(
+            self.test_req_path, sysconfig.get_python_version(), 'test')
 
     def _data_path(self, fragment):
         version_suffix = 'py%s' % platform.python_version()
@@ -71,7 +73,8 @@ class ApplicationTestCase(TmpDirTestCase):
             f.write('%s\n' % yodeploy_installable)
 
         virtualenv.create_ve(
-            self.test_ve_path, 'test', pypi, verify_req_install=False)
+            self.test_ve_path, sysconfig.get_python_version(), 'test', pypi,
+            verify_req_install=False)
 
 
 class ApplicationTest(ApplicationTestCase):

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -86,7 +86,8 @@ def create_ve(
             '-p', 'python%s' % python_version,
             '--no-site-packages', ve_dir))
 
-    install_requirements(ve_dir, pypi, req_file)
+    log.info('Installing requirements')
+    pip_install(ve_dir, pypi, '-r', req_file)
 
     if verify_req_install:
         log.info('Verifying requirements were met')
@@ -110,18 +111,13 @@ def create_ve(
         os.chdir(cwd)
 
 
-def install_requirements(ve_dir, pypi, req_file):
+def pip_install(ve_dir, pypi, *arguments):
     sub_log = logging.getLogger(__name__ + '.pip')
 
-    log.info('Installing requirements')
-
-    cmd = [
-        os.path.join('bin', 'python'), '-m', 'pip', 'install',
-        '-r', req_file,
-    ]
-
+    cmd = [os.path.join('bin', 'python'), '-m', 'pip', 'install']
     if pypi:
         cmd += ['--index-url', pypi]
+    cmd += arguments
 
     p = subprocess.Popen(cmd, cwd=ve_dir, stdout=subprocess.PIPE)
     for line in iter(p.stdout.readline, b''):

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -21,10 +21,18 @@ def sha224sum(filename):
     return m.hexdigest()
 
 
-def get_id(filename, platform):
+def get_python_version(compat):
+    """Return the version of Python that an app will use.
+
+    Based on the compat level.
+    """
+    return '2.7'
+
+
+def get_id(filename, python_version, platform):
     """Calculate the ID of a virtualenv for the given requirements.txt"""
     req_hash = sha224sum(filename)
-    return '%s-%s-%s' % (sysconfig.get_python_version(), platform, req_hash)
+    return '%s-%s-%s' % (python_version, platform, req_hash)
 
 
 def download_ve(repository, app, virtualenv_id, target='master',
@@ -51,7 +59,8 @@ def upload_ve(repository, app, virtualenv_id, target='master',
 
 
 def create_ve(
-        app_dir, platform, pypi=None, req_file='requirements.txt',
+        app_dir, python_version, platform, pypi=None,
+        req_file='requirements.txt',
         verify_req_install=True):
     log.info('Building virtualenv')
     ve_dir = os.path.join(app_dir, 'virtualenv')
@@ -65,7 +74,7 @@ def create_ve(
         check_requirements(ve_dir)
 
     relocateable_ve(ve_dir)
-    ve_id = get_id(os.path.join(app_dir, req_file), platform)
+    ve_id = get_id(os.path.join(app_dir, req_file), python_version, platform)
     with open(os.path.join(ve_dir, '.hash'), 'w') as f:
         f.write(ve_id)
         f.write('\n')

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -71,6 +71,7 @@ def create_ve(
         verify_req_install=True):
     log.info('Building virtualenv')
     ve_dir = os.path.join(app_dir, 'virtualenv')
+    ve_python = os.path.join(ve_dir, 'bin', 'python')
     req_file = os.path.join(os.path.abspath(app_dir), req_file)
 
     # The venv module makes a lot of our reclocateability problems go away, so
@@ -78,6 +79,12 @@ def create_ve(
     if python_version.startswith('3.'):
         subprocess.check_call((
             'python%s' % python_version, '-m', 'venv', ve_dir))
+        pip_version = subprocess.check_output((
+            ve_python, '-c', 'import ensurepip; print(ensurepip.version())'))
+        if pip_version < '9.':
+            pip_install(ve_dir, pypi, '-U', 'pip')
+        pip_install(ve_dir, pypi, 'wheel')
+
     elif python_version == sysconfig.get_python_version():
         virtualenv.create_environment(ve_dir, site_packages=False)
     else:

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -148,14 +148,28 @@ def check_requirements(ve_dir):
 
 
 def relocateable_ve(ve_dir, python_version):
+    # We can only do this for Python 2 under Python 2
+    if sys.version_info.major == 3 and python_version == '2.7':
+        cmd = [
+            os.path.join(ve_dir, 'bin', 'python'), '-c',
+            'import sys; sys.path.append("%(ve_path)s"); '
+            'sys.path.append("%(my_path)s"); '
+            'from yodeploy import virtualenv; '
+            'virtualenv.relocateable_ve("%(ve_dir)s", "%(python_version)s")'
+            % {
+                've_path': os.path.dirname(virtualenv.__file__),
+                'my_path': os.path.join(os.path.dirname(__file__), '..'),
+                've_dir': ve_dir,
+                'python_version': python_version,
+            }]
+        subprocess.check_call(cmd)
+        return
+
     log.debug('Making virtualenv relocatable')
 
     # Python 3 venv virtualenvs don't have these problems
     if python_version == '2.7':
-        # TODO: Turn virtualenv library calls into subprocess calls, when
-        # executed under Python 3
         virtualenv.make_environment_relocatable(ve_dir)
-
         fix_local_symlinks(ve_dir)
         remove_fragile_symlinks(ve_dir)
 

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -151,7 +151,8 @@ def check_requirements(ve_dir):
 
 
 def relocateable_ve(ve_dir, python_version):
-    # We can only do this for Python 2 under Python 2
+    # We can only call into the virtualenv module for operating on a
+    # Python 2 virtualenv, in Python 2.
     if sys.version_info.major == 3 and python_version == '2.7':
         cmd = [
             os.path.join(ve_dir, 'bin', 'python'), '-c',

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -26,7 +26,14 @@ def get_python_version(compat):
 
     Based on the compat level.
     """
-    return '2.7'
+    if compat < 5:
+        return '2.7'
+    if sys.version_info.major == 3:
+        return sysconfig.get_python_version()
+    return subprocess.check_output((
+        'python3', '-c',
+        'import sysconfig; print(sysconfig.get_python_version())'
+    )).strip()
 
 
 def get_id(filename, python_version, platform):


### PR DESCRIPTION
Supports Python 3 applications, when the compat level is 5.

Doing things across pythons can be a bit hacky. But a lot of the messiness of Python 2 VEs goes away with Python 3.

Fixes: yola/production#3779