### PR TITLE
Compare version objects, not tuples

### DIFF
--- a/yodeploy/hooks/django.py
+++ b/yodeploy/hooks/django.py
@@ -95,10 +95,10 @@ class DjangoApp(ApacheHostedApp, PythonApp):
 
     @property
     def django_version(self):
-        return tuple(parse_version(self.manage_py('version')))
+        return parse_version(self.manage_py('version'))
 
     def run_migrate_commands(self):
-        if self.django_version >= (1, 7,):
+        if self.django_version >= parse_version('1.7.0'):
             self.manage_py('migrate', '--noinput')
         else:
             self.manage_py('syncdb', '--noinput')

--- a/yodeploy/hooks/tests/test_django.py
+++ b/yodeploy/hooks/tests/test_django.py
@@ -1,6 +1,7 @@
 import unittest
 
 from mock import PropertyMock, call, patch
+from pkg_resources import parse_version
 
 from yodeploy.hooks.django import DjangoApp
 
@@ -29,13 +30,13 @@ class TestDjangoMigrateCommand(unittest.TestCase):
 
     def test_call_syncdb_for_django_1_5(self):
         """Call syncdb for django 1.5"""
-        self.mock_django_version.return_value = (1, 5)
+        self.mock_django_version.return_value = parse_version('1.5')
         self.dh.run_migrate_commands()
         self.mock_manage_py.assert_called_once_with('syncdb', '--noinput')
 
     def test_call_syncdb_then_migrate_for_django_1_5_with_migrations(self):
         """Call syncdb then migrate for Django 1.5 with migrations"""
-        self.mock_django_version.return_value = (1, 5)
+        self.mock_django_version.return_value = parse_version('1.5')
         self.dh.has_migrations = True
         self.dh.run_migrate_commands()
         self.mock_manage_py.assert_has_calls(
@@ -43,12 +44,12 @@ class TestDjangoMigrateCommand(unittest.TestCase):
 
     def test_call_migrate_for_django_1_7(self):
         """Call migrate for Django 1.7"""
-        self.mock_django_version.return_value = (1, 7)
+        self.mock_django_version.return_value = parse_version('1.7')
         self.dh.run_migrate_commands()
         self.mock_manage_py.assert_called_once_with('migrate', '--noinput')
 
     def test_call_migrate_for_django_1_10(self):
         """Call migrate for Django 1.10"""
-        self.mock_django_version.return_value = (1, 10)
+        self.mock_django_version.return_value = parse_version('1.10')
         self.dh.run_migrate_commands()
         self.mock_manage_py.assert_called_once_with('migrate', '--noinput')


### PR DESCRIPTION
```
>>> tuple(parse_version('1.4.22'))
('00000001', '00000004', '00000022', '*final')
```

That didn't compare very well with `(1, 7)`