### PR TITLE
Infer compat when bootstrapping yoconfigurator

### DIFF
--- a/scripts/local-deploy-bootstrap.py
+++ b/scripts/local-deploy-bootstrap.py
@@ -376,10 +376,11 @@ def get_from_pypi(app, version, pypi='https://pypi.python.org/simple/'):
 
 def infer_compat_version():
     """Return appropriate compat level for the python version"""
-    if sys.version_info.major == 2:
-        return 4
-    elif sys.version_info.major == 3:
-        return 5
+    major_version_to_compat = {
+        2: 4,
+        3: 5,
+    }
+    return major_version_to_compat[sys.version_info.major]
 
 
 def build_virtualenv(bootstrap=False, compat=None):

--- a/scripts/local-deploy-bootstrap.py
+++ b/scripts/local-deploy-bootstrap.py
@@ -375,7 +375,7 @@ def get_from_pypi(app, version, pypi='https://pypi.python.org/simple/'):
 
 
 def infer_compat_version():
-    """Return appropriate compat level for the python version running the bootstrap"""
+    """Return appropriate compat level for the python version"""
     if sys.version_info.major == 2:
         return 4
     elif sys.version_info.major == 3:

--- a/scripts/local-deploy-bootstrap.py
+++ b/scripts/local-deploy-bootstrap.py
@@ -388,12 +388,12 @@ def build_virtualenv(bootstrap=False, compat=None):
         raise Exception("build-virtualenv can't be found on PATH")
 
     # Already bootstrapped
+    command = ['build-virtualenv']
     if compat:
-        if call(('build-virtualenv', '--compat={}'.format(compat))) == 0:
-            return
-    else:
-        if call('build-virtualenv') == 0:
-            return
+        command.append('--compat={}'.format(compat))
+
+    if call(command) == 0:
+        return
 
     if not bootstrap:
         raise Exception('build-virtualenv failed')


### PR DESCRIPTION
based on python version used to run the bootstrap.

This is needed because yoconfigurator does not have a deploy/ directory
and previously we weren't checking for one.