### PR TITLE
Customise SSL ciphers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Flask==0.10.1
 Flask-HTTPAuth==2.5.0
-pyOpenSSL==16.2.0
 Tempita==0.5dev
 boto==2.42.0
 coverage==4.2.0

--- a/yodeploy/cmds/yodeploy_server.py
+++ b/yodeploy/cmds/yodeploy_server.py
@@ -39,19 +39,26 @@ def create_context():
     context.load_cert_chain(
         certfile=flask_app.config.server.ssl.cert_chain,
         keyfile=flask_app.config.server.ssl.key)
+    context.set_ciphers(flask_app.config.server.ssl.ciphers)
     return context
 
 
 class LegacySSLContext(object):
     """Wrap ssl.wrap_socket in a class with the SSLContext API"""
 
+    _ciphers = None
+
     def load_cert_chain(self, certfile, keyfile):
         self._certfile = certfile
         self._keyfile = keyfile
 
+    def set_ciphers(self, ciphers):
+        self._ciphers = ciphers
+
     def wrap_socket(self, sock, **kwargs):
         return ssl.wrap_socket(
-            sock, certfile=self._certfile, keyfile=self._keyfile, **kwargs)
+            sock, certfile=self._certfile, keyfile=self._keyfile,
+            ciphers=self._ciphers, **kwargs)
 
 
 if __name__ == '__main__':

--- a/yodeploy/cmds/yodeploy_server.py
+++ b/yodeploy/cmds/yodeploy_server.py
@@ -33,6 +33,7 @@ def parse_args(flask_app):
 def create_context():
     if hasattr(ssl, 'create_default_context'):  # Python >= 2.7.9
         context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.options |= ssl.OP_CIPHER_SERVER_PREFERENCE
     else:
         context = LegacySSLContext()
 

--- a/yodeploy/cmds/yodeploy_server.py
+++ b/yodeploy/cmds/yodeploy_server.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import ssl
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -29,11 +30,34 @@ def parse_args(flask_app):
     return opts
 
 
+def create_context():
+    if hasattr(ssl, 'create_default_context'):  # Python >= 2.7.9
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    else:
+        context = LegacySSLContext()
+
+    context.load_cert_chain(
+        certfile=flask_app.config.server.ssl.cert_chain,
+        keyfile=flask_app.config.server.ssl.key)
+    return context
+
+
+class LegacySSLContext(object):
+    """Wrap ssl.wrap_socket in a class with the SSLContext API"""
+
+    def load_cert_chain(self, certfile, keyfile):
+        self._certfile = certfile
+        self._keyfile = keyfile
+
+    def wrap_socket(self, sock, **kwargs):
+        return ssl.wrap_socket(
+            sock, certfile=self._certfile, keyfile=self._keyfile, **kwargs)
+
+
 if __name__ == '__main__':
     flask_app = create_app(find_deploy_config())
     opts = parse_args(flask_app)
     configure_logging(opts.debug, flask_app.config.server.logging)
-    context = (flask_app.config.server.ssl.cert_chain,
-               flask_app.config.server.ssl.key)
+    context = create_context()
     log.debug('Starting yodeploy server')
     flask_app.run(host=opts.listen, port=opts.port, ssl_context=context)


### PR DESCRIPTION
Default OpenSSL configuration still includes DES in many cases. Let's customise the cipher string, so that we can restrict ourselves to protocols we consider secure.