### PR TITLE
Make gunicorn use TLSv1.2 only

### DIFF
--- a/yodeploy/cmds/yodeploy_server.py
+++ b/yodeploy/cmds/yodeploy_server.py
@@ -38,7 +38,7 @@ class YodeployApplication(BaseApplication):
 
         self.cfg.set('bind', '{}:{}'.format(opts.listen, opts.port))
         self.cfg.set('ciphers', config.server.ssl.ciphers)
-        self.cfg.set('ssl_version', config.server.ssl.tls)
+        self.cfg.set('ssl_version', config.server.ssl.ssl_version)
         self.cfg.set('certfile', config.server.ssl.cert_chain)
         self.cfg.set('keyfile', config.server.ssl.key)
         self.cfg.set('workers', config.server.workers)

--- a/yodeploy/cmds/yodeploy_server.py
+++ b/yodeploy/cmds/yodeploy_server.py
@@ -38,7 +38,7 @@ class YodeployApplication(BaseApplication):
 
         self.cfg.set('bind', '{}:{}'.format(opts.listen, opts.port))
         self.cfg.set('ciphers', config.server.ssl.ciphers)
-        self.cfg.set('ssl-version', config.server.ssl.tls)
+        self.cfg.set('ssl_version', config.server.ssl.tls)
         self.cfg.set('certfile', config.server.ssl.cert_chain)
         self.cfg.set('keyfile', config.server.ssl.key)
         self.cfg.set('workers', config.server.workers)

--- a/yodeploy/cmds/yodeploy_server.py
+++ b/yodeploy/cmds/yodeploy_server.py
@@ -38,6 +38,7 @@ class YodeployApplication(BaseApplication):
 
         self.cfg.set('bind', '{}:{}'.format(opts.listen, opts.port))
         self.cfg.set('ciphers', config.server.ssl.ciphers)
+        self.cfg.set('ssl-version', config.server.ssl.tls)
         self.cfg.set('certfile', config.server.ssl.cert_chain)
         self.cfg.set('keyfile', config.server.ssl.key)
         self.cfg.set('workers', config.server.workers)


### PR DESCRIPTION
PCI Council set TLS 1.0 End of Life Date on June 30 2018, [details](https://blog.pcisecuritystandards.org/are-you-ready-for-30-june-2018-sayin-goodbye-to-ssl-early-tls).

Gunicorn, for now has a default value `ssl.PROTOCOL_SSLv23`, which allows auto-negotiation between client and server, including, deprected TLS 1.0. 

This PR prohibits auto-negotiation and allows only TLS 1.2. 

We will update this to [OP_NO_TLSv1](https://docs.python.org/2/library/ssl.html#ssl.OP_NO_TLSv1) once [this](https://github.com/benoitc/gunicorn/issues/1140) will be dealth with


Depends https://github.com/yola/chef/pull/2773