### PR TITLE
Revert always upgrade pip due to bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Change Log
 0.10.3
 -----
 
-* Revert Always upgrade `pip` for Python virtualenvs, it breaks venv creation
+* Revert Always upgrade `pip` for Python virtualenvs, it breaks pythhon 2 venv creation
 
 
 0.10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-0.10.3
+DEV
 -----
 
 * Revert Always upgrade `pip` for Python virtualenvs, it breaks pythhon 2 venv creation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+0.10.3
+-----
+
+* Revert Always upgrade `pip` for Python virtualenvs, it breaks venv creation
+
+
 0.10.2
 -----
 
@@ -14,8 +20,8 @@ Change Log
 0.10.0
 -----
 
-* Change expected template for NGINX's server block from 
-  `nginx/server_block.conf.template` to `nginx/server-block.template` 
+* Change expected template for NGINX's server block from
+  `nginx/server_block.conf.template` to `nginx/server-block.template`
 
 0.9.0
 -----

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -72,6 +72,7 @@ def create_ve(
         verify_req_install=True):
     log.info('Building virtualenv')
     ve_dir = os.path.join(app_dir, 'virtualenv')
+    ve_python = os.path.join(ve_dir, 'bin', 'python')
     req_file = os.path.join(os.path.abspath(app_dir), req_file)
 
     # The venv module makes a lot of our reclocateability problems go away, so
@@ -79,6 +80,11 @@ def create_ve(
     if python_version.startswith('3.'):
         subprocess.check_call((
             'python%s' % python_version, '-m', 'venv', ve_dir))
+        pip_version = subprocess.check_output((
+            ve_python, '-c', 'import ensurepip; print(ensurepip.version())'))
+        if parse_version(pip_version) < parse_version('9'):
+            pip_install(ve_dir, pypi, '-U', 'pip')
+        pip_install(ve_dir, pypi, 'wheel')
     elif python_version == sysconfig.get_python_version():
         virtualenv.create_environment(ve_dir, site_packages=False)
     else:
@@ -86,9 +92,6 @@ def create_ve(
             sys.executable, virtualenv.__file__.rstrip('c'),
             '-p', 'python%s' % python_version,
             '--no-site-packages', ve_dir))
-
-    pip_install(ve_dir, pypi, '-U', 'pip')
-    pip_install(ve_dir, pypi, 'wheel')
 
     log.info('Installing requirements')
     pip_install(ve_dir, pypi, '-r', req_file)


### PR DESCRIPTION
Currently new virtualenvs are failing with:

```
INFO:yodeploy.virtualenv.pip:Getting requirements to build wheel: started
INFO:yodeploy.virtualenv.pip:Getting requirements to build wheel: finished with status 'done'
ERROR: Exception:
Traceback (most recent call last):
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_internal/cli/base_command.py", line 178, in main
    status = self.run(options, args)
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_internal/commands/install.py", line 352, in run
    resolver.resolve(requirement_set)
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_internal/resolve.py", line 131, in resolve
    self._resolve_one(requirement_set, req)
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_internal/resolve.py", line 294, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_internal/resolve.py", line 242, in _get_abstract_dist_for
    self.require_hashes
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_internal/operations/prepare.py", line 362, in prepare_linked_requirement
    abstract_dist.prep_for_dist(finder, self.build_isolation)
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_internal/operations/prepare.py", line 169, in prep_for_dist
    self.install_backend_dependencies(finder=finder)
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_internal/operations/prepare.py", line 123, in install_backend_dependencies
    reqs = req.pep517_backend.get_requires_for_build_wheel()
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_vendor/pep517/wrappers.py", line 71, in get_requires_for_build_wheel
    'config_settings': config_settings
  File "/mnt/jenkins-workspaces/yodeploy/deploy/virtualenv/local/lib/python2.7/site-packages/pip/_vendor/pep517/wrappers.py", line 162, in _call_hook
    raise BackendUnavailable
BackendUnavailable
ERROR:yodeploy.virtualenv:pip exited non-zero (2)
build-virtualenv failed
```