### PR TITLE
Upgrade virtualenv package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Werkzeug == 0.14.1
 boto == 2.42.0
 gunicorn == 19.9.0
 requests == 2.21.0
-virtualenv == 15.1.0
+virtualenv == 16.7.5
 yoconfigurator == 0.5.2
 
 # Development dependencies:


### PR DESCRIPTION
It allows to create python 2 virtualenvs with newer pip and setuptools by default:
pip 9.0.1->19.2.3
setuptools 28.0.0->41.2.0