### PR TITLE
Pass string base directory to tarfile, not Python 2 unicode

### DIFF
--- a/yodeploy/util.py
+++ b/yodeploy/util.py
@@ -41,6 +41,8 @@ def extract_tar(tarball, root):
     directory to root.
     """
     workdir = os.path.dirname(root)
+    if sys.version_info[0] < 3:
+        workdir = workdir.encode(sys.getfilesystemencoding())
     tar = tarfile.open(tarball, 'r')
     try:
         members = tar.getmembers()


### PR DESCRIPTION
This was causing non-ascii tar contents to be un-extractable, on Python 2.