### PR TITLE
Always update pip for python3 virtualenvs

### DIFF
--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -72,7 +72,6 @@ def create_ve(
         verify_req_install=True):
     log.info('Building virtualenv')
     ve_dir = os.path.join(app_dir, 'virtualenv')
-    ve_python = os.path.join(ve_dir, 'bin', 'python')
     req_file = os.path.join(os.path.abspath(app_dir), req_file)
 
     # The venv module makes a lot of our reclocateability problems go away, so
@@ -80,10 +79,7 @@ def create_ve(
     if python_version.startswith('3.'):
         subprocess.check_call((
             'python%s' % python_version, '-m', 'venv', ve_dir))
-        pip_version = subprocess.check_output((
-            ve_python, '-c', 'import ensurepip; print(ensurepip.version())'))
-        if parse_version(pip_version) < parse_version('9'):
-            pip_install(ve_dir, pypi, '-U', 'pip')
+        pip_install(ve_dir, pypi, '-U', 'pip')
     elif python_version == sysconfig.get_python_version():
         virtualenv.create_environment(ve_dir, site_packages=False)
     else:


### PR DESCRIPTION
to resolve the problem when `pip 9.0.1`(default for ubuntu 18.04) can't install some packages.

Example:

pip 9.0.1:
```
(virtualenv) jenkins@neko:/var/lib/jenkins/workspaces/ws-template-importer$ pip install pandas -i https://xxx:xxx@yolapi.yola.net/simple/
Collecting pandas
  Downloading https://yolapi.yola.net/media/dists/pandas-1.1.5.tar.gz (5.2MB)
    100% |████████████████████████████████| 5.2MB 286kB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-vki5a2zj/pandas/setup.py", line 793, in <module>
        setup_package()
      File "/tmp/pip-build-vki5a2zj/pandas/setup.py", line 763, in setup_package
        ext_modules=maybe_cythonize(extensions, compiler_directives=directives),
      File "/tmp/pip-build-vki5a2zj/pandas/setup.py", line 520, in maybe_cythonize
        raise RuntimeError("Cannot cythonize without Cython installed.")
    RuntimeError: Cannot cythonize without Cython installed.

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-vki5a2zj/pandas/
```

new pip(20.3.2):
```
(virtualenv) jenkins@neko:/var/lib/jenkins/workspaces/ws-template-importer$ pip install pandas -i https://xxx:xxx@yolapi.yola.net/simple/
....
Successfully installed numpy-1.19.4 pandas-1.1.5 python-dateutil-2.8.1 pytz-2020.1 six-1.15.0
```