### PR TITLE
Patch for new pips

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Tempita == 0.5dev
 Werkzeug == 0.14.1
 boto == 2.42.0
 gunicorn == 19.9.0
+packaging == 20.8
 requests == 2.21.0
 virtualenv == 16.7.5
 yoconfigurator == 0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ Tempita == 0.5dev
 Werkzeug == 0.14.1
 boto == 2.42.0
 gunicorn == 19.9.0
-packaging == 20.8
 requests == 2.21.0
 virtualenv == 16.7.5
 yoconfigurator == 0.5.2

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -76,7 +76,8 @@ def create_ve(
 
     # The most recent pip versions dropped support for Python below 3.6
     # See changelog for v21.0 https://pip.pypa.io/en/stable/news
-    if python_version.startswith('3.6'):
+    parsed_python_version = parse_version(python_version)
+    if parsed_python_version >= parse_version('3.6.0'):
         subprocess.check_call((
             'python%s' % python_version, '-m', 'venv', ve_dir))
         pip_install(ve_dir, pypi, '-U', 'pip')

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -74,9 +74,9 @@ def create_ve(
     ve_dir = os.path.join(app_dir, 'virtualenv')
     req_file = os.path.join(os.path.abspath(app_dir), req_file)
 
-    # The venv module makes a lot of our reclocateability problems go away, so
-    # we only use the virtualenv library on Python 2.
-    if python_version.startswith('3.'):
+    # The mos recent pip versions dropped support for Python below 3.6
+    # See changelog for v21.0 https://pip.pypa.io/en/stable/news
+    if python_version.startswith('3.6'):
         subprocess.check_call((
             'python%s' % python_version, '-m', 'venv', ve_dir))
         pip_install(ve_dir, pypi, '-U', 'pip')

--- a/yodeploy/virtualenv.py
+++ b/yodeploy/virtualenv.py
@@ -74,7 +74,7 @@ def create_ve(
     ve_dir = os.path.join(app_dir, 'virtualenv')
     req_file = os.path.join(os.path.abspath(app_dir), req_file)
 
-    # The mos recent pip versions dropped support for Python below 3.6
+    # The most recent pip versions dropped support for Python below 3.6
     # See changelog for v21.0 https://pip.pypa.io/en/stable/news
     if python_version.startswith('3.6'):
         subprocess.check_call((


### PR DESCRIPTION
pip starting from version 21.0 will drop the support for python 2 and 3.5.

See https://pip.pypa.io/en/stable/news