### PR TITLE
encodestring was removed in python 3.9

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -68,7 +68,7 @@ class S3Client(object):
         cleartext = cleartext.encode()
 
         mac = hmac.new(self.secret_key, cleartext, hashlib.sha1)
-        signature = base64.encodestring(mac.digest()).rstrip()
+        signature = base64.encodebytes(mac.digest()).rstrip()
 
         req.add_header('Authorization',
                        b'AWS %s:%s' % (self.access_key, signature))

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -68,7 +68,7 @@ class S3Client(object):
         cleartext = cleartext.encode()
 
         mac = hmac.new(self.secret_key, cleartext, hashlib.sha1)
-        signature = base64.encodebytes(mac.digest()).rstrip()
+        signature = base64.b64encode(mac.digest()).rstrip()
 
         req.add_header('Authorization',
                        b'AWS %s:%s' % (self.access_key, signature))


### PR DESCRIPTION
It was deprecated in 3.1 and is an alias of encodebytes